### PR TITLE
Allow to set param index in params array with 'index' key

### DIFF
--- a/ProtoplugFiles/include/core/manageparams.lua
+++ b/ProtoplugFiles/include/core/manageparams.lua
@@ -90,14 +90,19 @@ return function(args)
 	for key, param in pairs(args) do
 		param.type = param.type or "double"
 		param.name = param.name or key
-		param.index = index
+		param.index = param.index or index
 		param = paramConstructors[param.type](param)
+
+		if type(param.name) ~= "string" then
+			param.name = ("Param %i (%s)"):format(param.index, param.type)
+		end
+
 		param.set = function(val)
 			plugin.setParameter(param.index, param.Value2Raw(val))
 			param.changed(param.getValue())
 		end
 		params[key] = param
-		index2param[index] = param
+		index2param[param.index] = param
 		index = index + 1
 	end
 


### PR DESCRIPTION
Also, if param key is not a string and param.name is nil, create param name from index and type.

Example usage:

```
params = plugin.manageParams {
    {
        name = "Length",
        type = "int",
    },
    {
        name = "Feedback",
        index = 2,
        type = "int",
        ....
    },
    {
        type = "int",
        index = 1,
        ...
    }
}
```

Would yield these parameters in the given order:
1. "Length"
2. "Param 1 (int)"
3. "Feedback"
