### PR TITLE
volume to velocity transformer

### DIFF
--- a/ProtoplugFiles/generators/vol2vel.lua
+++ b/ProtoplugFiles/generators/vol2vel.lua
@@ -1,0 +1,16 @@
+-- volume to velocity transformer
+-- (c) Severak 2021
+
+require "include/protoplug"
+
+volume = 100
+
+function plugin.processBlock(samples, smax, midiBuf)
+	for ev in midiBuf:eachEvent() do
+		if ev:isNoteOn() then
+			ev:setVel(volume)
+		elseif ev:isControl() and ev:getControlNumber()==7 then
+		    volume = ev:getControlValue()
+		end	
+	end	
+end


### PR DESCRIPTION
I have some noname cheap MIDI controller, which has some problems with setting right velocity when playing live. I hit either too hard or too soft. This script is filter which solves this problem - it let me control velocity via volume slider/knob on my controller. This can be useful for others too IMHO.

Test it with some sound which sounds very different by velocity - e.g. EPIANO2 patch for Dexed (DX7).